### PR TITLE
Single camera for better opt

### DIFF
--- a/hloc/reconstruction.py
+++ b/hloc/reconstruction.py
@@ -48,6 +48,14 @@ def get_image_ids(database_path: Path) -> Dict[str, int]:
     db.close()
     return images
 
+def unique_camera_ids(database_path: Path):
+    db = COLMAPDatabase.connect(database_path)
+    for image_id, _ in db.execute("SELECT image_id, name FROM images"):                       
+        db.execute(
+            "UPDATE images SET camera_id=? WHERE image_id=?", (1, image_id),
+                   )
+    db.commit()
+    db.close()
 
 def run_reconstruction(sfm_dir: Path,
                        database_path: Path,
@@ -119,6 +127,7 @@ def main(sfm_dir: Path,
                    min_match_score, skip_geometric_verification)
     if not skip_geometric_verification:
         estimation_and_geometric_verification(database, pairs, verbose)
+    unique_camera_ids(database)
     reconstruction = run_reconstruction(
         sfm_dir, database, image_dir, verbose, mapper_options)
     if reconstruction is not None:


### PR DESCRIPTION
Setting the single camera for video reconstruction by rewriting cams to '1' in db, which would helps optimization.